### PR TITLE
Add VPATH to help make find prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ WORKDIR=build
 CONFDIR=configs
 OUTPUTDIR=images
 TMPFILE=/tmp/$(project_name)
+VPATH=$(WORKDIR):$(OUTPUTDIR)
 
 CONFIG_X64=kernel.x86
 BZIMAGE_X64=bzImage.x86


### PR DESCRIPTION
Currently make instructions will fail to detect if depencies are already built and always rebuild everything because it only searches for files in the project root while our build products end up in build/ or images/.

Use VPATH to add those two directories as search paths as documented at https://www.gnu.org/software/make/manual/html_node/General-Search.html